### PR TITLE
LRQA-57804 | Removing Stable Tests from quarantine

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormRules.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormRules.testcase
@@ -38,7 +38,7 @@ definition {
 	@description = "This is a use case for LPS-70446."
 	@priority = "5"
 	test ConfigureAutofillRule {
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "FormRules#ConfigureAutofillRule";
 		var portalURL = PropsUtil.get("portal.url");
@@ -159,7 +159,7 @@ definition {
 	@priority = "5"
 	test ConfigureCalculateRule {
 		property test.name.skip.portal.instance = "FormRules#ConfigureCalculateRule";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 		var portalURL = PropsUtil.get("portal.url");
 
 		Navigator.openURL();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
@@ -71,7 +71,7 @@ definition {
 	@priority = "4"
 	test Add30Fields {
 		property test.name.skip.portal.instance = "Forms#Add30Fields";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -102,7 +102,7 @@ definition {
 	test AddElementSetsWithTranslation {
 		property test.name.skip.portal.instance = "Forms#AddElementSetsWithTranslation";
 		property testray.component.names = "Training";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -587,7 +587,7 @@ definition {
 	@priority = "4"
 	test AddFormWithDuplicateTextFields {
 		property test.name.skip.portal.instance = "Forms#AddFormWithDuplicateTextFields";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -1137,7 +1137,7 @@ definition {
 	@description = "This is a use case for LPS-98073."
 	@priority = "5"
 	test CreateReadUpdateDeleteImageField {
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 		property test.name.skip.portal.instance = "Forms#SubmitFormWithRequiredImageField";
 
 		ProductMenu.gotoPortlet(
@@ -1332,7 +1332,7 @@ definition {
 	@priority = "5"
 	test DeletePages {
 		property test.name.skip.portal.instance = "Forms#DeletePages";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -1551,7 +1551,7 @@ definition {
 	@priority = "4"
 	test EditAllFormFieldNames {
 		property test.name.skip.portal.instance = "Forms#EditAllFormFieldNames";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -1918,7 +1918,7 @@ definition {
 	@priority = "2"
 	test EditFormWithUpdatedSiteAndUserLocale {
 		property test.name.skip.portal.instance = "Forms#EditFormWithUpdatedSiteAndUserLocale";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -1998,7 +1998,7 @@ definition {
 	@priority = "4"
 	test EditTranslatedGridField {
 		property test.name.skip.portal.instance = "Forms#EditTranslatedGridField";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -2230,7 +2230,7 @@ definition {
 	test PreviewAndPublishForm {
 		property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
 		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -3566,7 +3566,7 @@ definition {
 	@priority = "4"
 	test SubmitFormWithMultipleFieldsAndViewEntriesViaDescriptiveDisplay {
 		property test.name.skip.portal.instance = "Forms#SubmitFormWithMultipleFieldsAndViewEntriesViaDescriptiveDisplay";
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		Navigator.openURL();
 
@@ -3839,7 +3839,7 @@ definition {
 	@priority = "5"
 	test SubmitFormWithRequiredImageField {
 		property test.name.skip.portal.instance = "Forms#SubmitFormWithRequiredImageField";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		ProductMenu.gotoPortlet(
 			category = "Content &amp; Data",
@@ -4596,7 +4596,7 @@ definition {
 	@priority = "4"
 	test ViewDefaultFieldNamesWithPunctuationCharacters {
 		property test.name.skip.portal.instance = "Forms#ViewDefaultFieldNamesWithPunctuationCharacters";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -4659,7 +4659,7 @@ definition {
 	@priority = "4"
 	test ViewFieldValidationIsNotBypassedWhenNextButtonIsHitTwice {
 		property test.name.skip.portal.instance = "Forms#ViewFieldValidationIsNotBypassedWhenNextButtonIsHitTwice";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -4920,7 +4920,7 @@ definition {
 	test ViewSuccessPage {
 		property test.name.skip.portal.instance = "Forms#ViewSuccessPage";
 		property testray.component.names = "Training";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsJumpToPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsJumpToPage.testcase
@@ -35,7 +35,7 @@ definition {
 	@priority = "4"
 	test ViewFormRulesSummary {
 		property test.name.skip.portal.instance = "FormsJumpToPage#ViewFormRulesSummary";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -164,7 +164,7 @@ definition {
 	@priority = "5"
 	test ViewPagesAfterJump {
 		property test.name.skip.portal.instance = "FormsJumpToPage#ViewPagesAfterJump";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -476,7 +476,7 @@ definition {
 	@priority = "3"
 	test ViewRuleAfterOptionValueEdit {
 		property test.name.skip.portal.instance = "FormsJumpToPage#ViewRuleAfterOptionValueEdit";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 
@@ -615,7 +615,7 @@ definition {
 	@priority = "4"
 	test ViewRuleAfterPageNameChange {
 		property test.name.skip.portal.instance = "FormsJumpToPage#ViewRuleAfterPageNameChange";
-		property portal.acceptance = "quarantine";
+		property portal.acceptance = "true";
 
 		Navigator.openURL();
 


### PR DESCRIPTION
Removing stable test from quarantine:

FormRules#ConfigureAutofillRule
FormRules#ConfigureCalculateRule
Forms#Add30Fields
Forms#AddElementSetsWithTranslation
Forms#AddFormWithDuplicateTextFields
Forms#DeletePages
Forms#EditAllFormFieldNames
Forms#EditFormWithUpdatedSiteAndUserLocale
Forms#EditTranslatedGridField
Forms#PreviewAndPublishForm
Forms#ViewDefaultFieldNamesWithPunctuationCharacters
Forms#ViewFieldValidationIsNotBypassedWhenNextButtonIsHitTwice
Forms#ViewSuccessPage
Forms#SubmitFormWithRequiredImageField
FormsJumpToPage#ViewFormRulesSummary
FormsJumpToPage#ViewPagesAfterJump
FormsJumpToPage#ViewRuleAfterOptionValueEdit
FormsJumpToPage#ViewRuleAfterPageNameChange